### PR TITLE
Remove stretched-link styles and use explicit a hrefs

### DIFF
--- a/client/app/index.html
+++ b/client/app/index.html
@@ -44,7 +44,7 @@
             <div class="col-lg-6 text-center">
                 <div class="card">
                     <div class="card-body">
-                      <h3 class="card-title"><a href="elkgraph.html">Interactive Editor</a></h3>
+                        <h3 class="card-title"><a href="elkgraph.html">Interactive Editor</a></h3>
                         <p class="card-text">
                             Interactively edit a textual description of a graph
                             while a corresponding diagram is generated on-the-fly.
@@ -76,7 +76,7 @@
             <div class="col-lg-6 text-center">
                 <div class="card h-100">
                     <div class="card-body">
-                      <h3 class="card-title"><a href="examples.html">Examples</a></h3>
+                        <h3 class="card-title"><a href="examples.html">Examples</a></h3>
                         <p class="card-text">
                             An annotated collection of example graphs.
                             Their main purpose is to illustrate
@@ -97,7 +97,7 @@
                 <div class="col-lg-6 text-center">
                     <div class="card">
                         <div class="card-body">
-                          <h3 class="card-title"><a href="models.html">Model Browser</a></h3>
+                            <h3 class="card-title"><a href="models.html">Model Browser</a></h3>
                             <p class="card-text">
                                 An interactive browser
                                 for the Eclipse Layout Kernel's
@@ -115,7 +115,7 @@
             <div class="col-lg-6 text-center">
                 <div class="card">
                     <div class="card-body">
-                      <h3 class="card-title"><a href="conversion.html">Graph Format Conversion</a></h3>
+                        <h3 class="card-title"><a href="conversion.html">Graph Format Conversion</a></h3>
                         <p class="card-text">
                             A side-by-side view of two graph formats.
                             Allows to interactively convert one graph format into another.

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -44,9 +44,9 @@
             <div class="col-lg-6 text-center">
                 <div class="card">
                     <div class="card-body">
-                        <h3 class="card-title">Interactive Editor</h3>
+                      <h3 class="card-title"><a href="elkgraph.html">Interactive Editor</a></h3>
                         <p class="card-text">
-                            Interactively edit a textual description of a graph 
+                            Interactively edit a textual description of a graph
                             while a corresponding diagram is generated on-the-fly.
                             Basically,
                             build your own graphs
@@ -56,29 +56,27 @@
                         </p>
                         <div class="row">
                             <div class="col small border-right">
-                                <h5><pre id="select-elkt" class="m-0">elkt</pre></h5>
+                                <h5><pre id="select-elkt" class="m-0"><a href="elkgraph.html">elkt</a></pre></h5>
                                 <p class="card-text">
                                     ELK's <a href="https://www.eclipse.org/elk/documentation/tooldevelopers/graphdatastructure/elktextformat.html" class="nestedLink">textual graph DSL.</a>
                                     Layout is performed on the server using Java.
                                 </p>
                             </div>
                             <div class="col small">
-                                <h5><pre id="select-json" class="m-0">json</pre></h5>
+                                <h5><pre id="select-json" class="m-0"><a href="json.html">json</a></pre></h5>
                                 <p class="card-text">
                                     ELK's <a href="https://www.eclipse.org/elk/documentation/tooldevelopers/graphdatastructure/jsonformat.html" class="nestedLink">json format.</a>
                                     Layout is performed within your browser using elkjs.
                                 </p>
                             </div>
                         </div>
-                        <a id="link-elkt" href="elkgraph.html" class="stretched-link"></a>
-                        <a id="link-json" href="json.html" class="stretched-link"></a>
                     </div>
                 </div>
             </div>
             <div class="col-lg-6 text-center">
                 <div class="card h-100">
                     <div class="card-body">
-                        <h3 class="card-title">Examples</h3>
+                      <h3 class="card-title"><a href="examples.html">Examples</a></h3>
                         <p class="card-text">
                             An annotated collection of example graphs.
                             Their main purpose is to illustrate
@@ -90,7 +88,6 @@
                             <a href="https://github.com/eclipse/elk-models" class="nestedLink">models repository</a>.
                             Pull-requests with concise and new examples are very welcome.
                         </p>
-                        <a href="examples.html" class="stretched-link"></a>
                     </div>
                 </div>
             </div>
@@ -100,7 +97,7 @@
                 <div class="col-lg-6 text-center">
                     <div class="card">
                         <div class="card-body">
-                            <h3 class="card-title">Model Browser</h3>
+                          <h3 class="card-title"><a href="models.html">Model Browser</a></h3>
                             <p class="card-text">
                                 An interactive browser
                                 for the Eclipse Layout Kernel's
@@ -112,14 +109,13 @@
                             <p class="card-text">
                                 Layout is performed within your browser using elkjs (latest).
                             </p>
-                            <a href="models.html" class="stretched-link"></a>
                         </div>
                     </div>
                 </div>
             <div class="col-lg-6 text-center">
                 <div class="card">
                     <div class="card-body">
-                        <h3 class="card-title">Graph Format Conversion</h3>
+                      <h3 class="card-title"><a href="conversion.html">Graph Format Conversion</a></h3>
                         <p class="card-text">
                             A side-by-side view of two graph formats.
                             Allows to interactively convert one graph format into another.
@@ -129,7 +125,6 @@
                         <p class="card-text">
                             Supports ELK's Xtext-based <code>elkt</code>, <code>json</code>, and <code>elkg</code> (XMI) formats.
                         </p>
-                        <a href="conversion.html" class="stretched-link"></a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Hi there

Small random PR here, but I found it hard to tell that the "cards" on the website were actually clickable links so I didn't realize that those interactive examples could be navigated. I changed the headers to links so that it is more clear