### PR TITLE
update ci to use node 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         java-version: [ 11 ]
-        node-version: [ 12.x ]
+        node-version: [ 20.x ]
 
     steps:
     # Checkout the repository of both elk and elkjs, place them next to each other. 


### PR DESCRIPTION
see https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/ and https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/