### PR TITLE
Update README.md: publish port when running image

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This project provides a container based runtime environment for the
 ## Usage
 
 Build and/or run image with [Docker](https://www.docker.com). You can start
-container on pre-built image with `docker run ghcr.io/kieler/elk-live:master`.
+container on pre-built image with `docker run -p 8080:8080 ghcr.io/kieler/elk-live:master`, then access via your browser at http://localhost:8080/ (or `-p [PORT]:8080` to access from a different `PORT`).
 
 ### Local image build
 


### PR DESCRIPTION
When running the docker image, a port must be published in order to access from localhost. I'm a docker newbie so I had to figure out specifying a port 😅 ([relevant stackoverflow explanation here](https://stackoverflow.com/a/47594352)) and specifying this explicitly would have helped me.

I totally understand if this knowledge is presumed/seems not worth documenting explicitly.