### PR TITLE
Force `PARENT` edge coords in the JSON editor.

### DIFF
--- a/client/src/json/editor.ts
+++ b/client/src/json/editor.ts
@@ -90,6 +90,12 @@ setupModelLink(editor, (event) => {
 function updateModel() {
     try {
         let json = JSON5.parse(editor.getValue());
+
+        // Force PARENT edge coordinates, so that Sprotty can draw the graph correctly.
+        let props = json?.properties || {};
+        props["org.eclipse.elk.json.edgeCoords"] = "PARENT";
+        json.properties = props;
+
         monaco.editor.setModelMarkers(editor.getModel(), "", []);
 
         // Prepare the elk version selected by the user

--- a/client/src/json/editor.ts
+++ b/client/src/json/editor.ts
@@ -92,7 +92,7 @@ function updateModel() {
         let json = JSON5.parse(editor.getValue());
 
         // Force PARENT edge coordinates, so that Sprotty can draw the graph correctly.
-        let props = json?.properties || {};
+        let props = json.properties || {};
         props["org.eclipse.elk.json.edgeCoords"] = "PARENT";
         json.properties = props;
 


### PR DESCRIPTION
This ensures that Sprotty is able to draw the graph correctly, and is a part of the solution to eclipse/elk#901 .
It also resolves #8.

Note however that it won't do anything until `elk-live` is using a version of ELK that incorporates eclipse/elk#1071 .

It appears to be consistent with older/current versions of ELK, i.e. they appear to simply ignore the new property, and their behavior is unchanged.