### PR TITLE
Introduce multi-arch container images

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -13,17 +13,27 @@ on:
   pull_request:
     branches: ["master"]
   workflow_dispatch: # manual triggering, for debugging purposes
-    
+
 env:
   # Use docker.io for Docker Hub if empty
   REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
+  AMD_TAG: amd64
+  ARM_TAG: arm64
 
 jobs:
-
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm]
+        include:
+          - os: ubuntu-latest
+            architecture: amd64
+          - os: ubuntu-24.04-arm
+            architecture: arm64
+
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
       packages: write
@@ -61,11 +71,12 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ steps.meta.outputs.tags }}-${{ matrix.architecture }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -76,3 +87,41 @@ jobs:
           package-type: "container"
           min-versions-to-keep: 10
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  combine-platforms:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      # Set up Docker Buildx
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Log in to GitHub Container Registry (ghcr)
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      # Extract metadata (tags) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      # Pull existing platform images
+      - name: Pull amd64 image
+        run: docker pull --platform linux/amd64 ${{ steps.meta.outputs.tags }}-${{ env.AMD_TAG }}
+
+      - name: Pull arm64 image
+        run: docker pull --platform linux/arm64 ${{ steps.meta.outputs.tags }}-${{ env.ARM_TAG }}
+
+      # Create a multi-platform image
+      - name: Create and push multi-platform image
+        run: |
+          docker buildx imagetools create \
+            --tag ${{ steps.meta.outputs.tags }} \
+            ${{ steps.meta.outputs.tags }}-${{ env.AMD_TAG }} \
+            ${{ steps.meta.outputs.tags }}-${{ env.ARM_TAG }}


### PR DESCRIPTION
* Adds support for Apple M-series chips

This approach uses matrix builds and combines Docker image tags in a later step since the multi-arch build via QEMU took almost 15 minutes in my tests.