### PR TITLE
update maven search links to new url

### DIFF
--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -53,7 +53,7 @@ module.exports = async function (env) {
     const javaElkVersions = [ 'snapshot' ]; // latest snapshot/nightly at the time of building 
     // Query released ELK versions using maven's REST API
     try {
-        const response = await fetch("https://search.maven.org/solrsearch/select?q=g:%22org.eclipse.elk%22+AND+a:%22org.eclipse.elk.core%22&core=gav&wt=json")
+        const response = await fetch("https://central.sonatype.com/solrsearch/select?q=g:%22org.eclipse.elk%22+AND+a:%22org.eclipse.elk.core%22&core=gav&wt=json")
                                     .then(res => res.json());
         response.response.docs.forEach(doc => {
             javaElkVersions.push(doc.v);

--- a/server/elk-layout-version/build.gradle
+++ b/server/elk-layout-version/build.gradle
@@ -19,7 +19,7 @@ def getJsonFromRest(String url) {
 }
 
 def isLayoutAlgorithmExistsForVersion(String algorithm, String version) {
-    def baseUrl = "https://search.maven.org/solrsearch/select"
+    def baseUrl = "https://central.sonatype.com/solrsearch/select"
     def query = "?q=g:%22org.eclipse.elk%22+AND+a:%22${algorithm}%22+AND+v:%22$version%22&core=gav&wt=json"
     return getJsonFromRest(baseUrl + query).response.numFound > 0  
 }

--- a/server/settings.gradle
+++ b/server/settings.gradle
@@ -17,7 +17,7 @@ def getJsonFromRest(String url) {
 	def json = new JsonSlurper().parseText(request.getInputStream().getText())
 	return json
 }
-def queryElkVersionsUrl = "https://search.maven.org/solrsearch/select?q=g:%22org.eclipse.elk%22+AND+a:%22org.eclipse.elk.core%22&core=gav&wt=json"
+def queryElkVersionsUrl = "https://central.sonatype.com/solrsearch/select?q=g:%22org.eclipse.elk%22+AND+a:%22org.eclipse.elk.core%22&core=gav&wt=json"
 def elkVersions = getJsonFromRest(queryElkVersionsUrl).response.docs.collect{it.v}
 
 // The subprojects will be called like the version number, e.g. '0.6.0'


### PR DESCRIPTION
The old url `search.maven.org` no longer works and has to be replaced with `centreal.sonatype.com`.