### PR TITLE
Add gradle command to only run without rebuilding jars.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,5 +62,5 @@ jobs:
         CI: true
     - name: Build server-side
       run: |
-        ./gradlew jettyRun --args='--root ../../ --mode CHECK'
+        ./gradlew buildAndRun --args='--root ../../ --mode CHECK'
       working-directory: /home/runner/work/elk-live/elk-live/elk-live/server/

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -8,4 +8,4 @@ tasks:
     ./server/gradlew -p server build
   command: |
     cd server
-    ./gradlew jettyRun
+    ./gradlew buildAndRun

--- a/README.md
+++ b/README.md
@@ -32,10 +32,12 @@ yarn install
 yarn run build
 
 cd ../server
-./gradlew jettyRun
+./gradlew buildAndRun
 ```
 
 Then point your web browser to http://localhost:8080/
+
+Each  subsequent run should work with `./gradlew onlyRun` without rebuilding the layout jars.
 
 This project provides a container based runtime environment for the
 [elk-live](https://github.com/kieler/elk-live) project.

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -38,7 +38,7 @@ subprojects {
 	apply plugin: 'org.xtext.xtend'
 	apply plugin: 'eclipse'
 	
-	sourceCompatibility = '11'
+	sourceCompatibility = '17'
 
 	xtext {
 		// Since the layout version projects don't contain xtext-related code,

--- a/server/elkgraph-web/build.gradle
+++ b/server/elkgraph-web/build.gradle
@@ -31,7 +31,7 @@
 // TODO condition is not the best
 def layoutVersionProjects = rootProject.subprojects.findAll{it.name.startsWith('0')}
 
-task jettyRun(type: JavaExec) {
+task buildAndRun(type: JavaExec) {
 	dependsOn(sourceSets.main.runtimeClasspath)
 	classpath = sourceSets.main.runtimeClasspath.filter{it.exists()}
 	main = 'de.cau.cs.kieler.elkgraph.web.ServerLauncher'
@@ -43,7 +43,18 @@ task jettyRun(type: JavaExec) {
 	description = 'Starts the ELK Graph server'
 }
 
-// We require that all layout version specific jars are built
+task onlyRun(type: JavaExec) {
+	dependsOn(sourceSets.main.runtimeClasspath)
+	classpath = sourceSets.main.runtimeClasspath.filter{it.exists()}
+	main = 'de.cau.cs.kieler.elkgraph.web.ServerLauncher'
+	args = ["--root", rootProject.file('..')]
+	systemProperty "elkJars", layoutVersionProjects.collect{it.jar.archivePath}.join(',')
+	standardInput = System.in
+	group = 'run'
+	description = 'Runs the ELK Graph server without building the layout version jars'
+}
+
+// We require that all layout version specific jars are built for `buildAndRun`. This is not executed when doing `onlyRun` hence, the jars are not rebuilt
 layoutVersionProjects.each {
-    jettyRun.dependsOn(it.jar)
+    buildAndRun.dependsOn(it.jar)
 }


### PR DESCRIPTION
Also renamed jettyRun to buildAndRun to differentiate between the two commands.