### PR TITLE
A quick&dirty fix for parsing version from jarPath.

### DIFF
--- a/server/elkgraph-web/src/main/java/de/cau/cs/kieler/elkgraph/web/ElkLayoutVersionRegistry.xtend
+++ b/server/elkgraph-web/src/main/java/de/cau/cs/kieler/elkgraph/web/ElkLayoutVersionRegistry.xtend
@@ -34,7 +34,9 @@ final class ElkLayoutVersionRegistry {
         }
         val strings = System.getProperty("elkJars").split(',')
         return newImmutableMap(strings.map [ jarPath |
-            jarPath.substring(jarPath.lastIndexOf('-') - 5, jarPath.lastIndexOf('-')) ->
+        	val elkJarVersion = jarPath.substring(jarPath.lastIndexOf('/') + 1, jarPath.lastIndexOf('-'))
+        	LOG.info("registering elkJar " + jarPath + " as version " + elkJarVersion)
+            elkJarVersion ->
                 new ElkLayoutVersionWrapper(jarPath)
         ])
     }


### PR DESCRIPTION
jarPaths look like the following lines
- /elklive/server/elkgraph-web/build/elk-layout-versions/0.10.0/build/libs/0.10.0-0.1.0.jar
- /elklive/server/elkgraph-web/build/elk-layout-versions/0.10.0/build/libs/0.9.1-0.1.0.jar
- /elklive/server/elkgraph-web/build/elk-layout-versions/0.10.0/build/libs/0.9.0-0.1.0.jar

The old code works only for version strings that have a length of exactly 5 characters. This scheme breaks with version 0.10.0 and, thus, parsing no longer works.

*Now, we use everything between the last '/' and the last '-' in the jarPath.*