### PR TITLE
Make logo switch with dark mode, using CSS

### DIFF
--- a/client/app/common.css
+++ b/client/app/common.css
@@ -39,13 +39,13 @@ body.elk-dark-mode {
 }
 
 #darkModeToggle {
-    margin-left: 16px;
+    margin-right: 16px;
 }
 
 #darkModeToggle.front-page {
     position: absolute;
-    top: 16px;
-    right: 16px;
+    top: 32px;
+    right: 32px;
 }
 
 .elk-dark-mode #example-description pre {
@@ -71,4 +71,28 @@ body.elk-dark-mode {
 .elk-dark-mode #page-theme,
 .elk-dark-mode #elk-version {
     filter: invert(0.8) hue-rotate(180deg);
+}
+
+.elk-logo-large {
+    width: 150px;
+    height: 88px;
+    display: inline-block;
+    background-repeat: no-repeat;
+    background-image: url(img/elk.svg);
+}
+
+.elk-logo-small {
+    width: 51px;
+    height: 30px;
+    display: inline-block;
+    background-repeat: no-repeat;
+    background-image: url(img/elk_small.svg);
+}
+
+.elk-dark-mode .elk-logo-large {
+    background-image: url(img/elk_light.svg);
+}
+
+.elk-dark-mode .elk-logo-small {
+    background-image: url(img/elk_small_light.svg);
 }

--- a/client/app/index.html
+++ b/client/app/index.html
@@ -31,7 +31,7 @@
     <div class="container">
         <div class="row justify-content-md-center mt-5 mb-5">
             <div class="col-md-8 text-center">
-                <img src="img/elk.svg" width="150" class="mb-3" alt="">
+                <div class="elk-logo-large mb-3"></div>
                 <h1>ELK Demonstrators</h1>
                 <p class="lead">
                     Automatic layout algorithms compute layouts for diagrams.

--- a/client/src/elkgraph/elkgraph_template.html
+++ b/client/src/elkgraph/elkgraph_template.html
@@ -18,7 +18,7 @@
 <body class="d-flex flex-column">
 	<nav class="navbar navbar-expand-sm navbar-default flex-nowrap">
 		<a class="navbar-brand w-100" href="index.html">
-            <img src="img/elk_small.svg" height="30" class="d-inline-block align-top mr-1" alt="">  
+            <span class="elk-logo-small align-top mr-1"></span>
             ELK Demonstrators
         </a>
         <div class="w-100 text-center">

--- a/client/src/examples/examples_template.html
+++ b/client/src/examples/examples_template.html
@@ -36,7 +36,7 @@
 <body class="d-flex flex-column">
     <nav class="navbar navbar-expand-sm navbar-default flex-nowrap">
         <a class="navbar-brand w-100" href="index.html">
-            <img src="img/elk_small.svg" height="30" class="d-inline-block align-top mr-1" alt="">
+            <span class="elk-logo-small align-top mr-1"></span>
             ELK Demonstrators
         </a>
         <div class="w-100 text-center">

--- a/client/src/json/json_template.html
+++ b/client/src/json/json_template.html
@@ -18,7 +18,7 @@
 <body class="d-flex flex-column">
     <nav class="navbar navbar-expand-sm navbar-default flex-nowrap">
 		<a class="navbar-brand w-100" href="index.html">
-            <img src="img/elk_small.svg" height="30" class="d-inline-block align-top mr-1" alt="">  
+            <span class="elk-logo-small align-top mr-1"></span>
             ELK Demonstrators
         </a>
         <div class="w-100 text-center">

--- a/client/src/models/models_template.html
+++ b/client/src/models/models_template.html
@@ -62,7 +62,7 @@
 <body class="d-flex flex-column">
     <nav class="navbar navbar-expand-sm navbar-default flex-nowrap">
 		<a class="navbar-brand" href="index.html">
-            <img src="img/elk_small.svg" height="30" class="d-inline-block align-top mr-1" alt="">  
+            <span class="elk-logo-small align-top mr-1"></span>
             ELK Demonstrators
         </a>
         <span class="navbar-brand mb-0 h1">Model Browser</span>


### PR DESCRIPTION
This is an alternative approach to #123, using only CSS to update the logo images with the dark mode switch.