### PR TITLE
Restore left margin on dark mode toggle

### DIFF
--- a/client/app/common.css
+++ b/client/app/common.css
@@ -39,6 +39,7 @@ body.elk-dark-mode {
 }
 
 #darkModeToggle {
+    margin-left: 16px;
     margin-right: 16px;
 }
 


### PR DESCRIPTION
It turns out the left margin on the dark mode toggle is needed after all.
Without it:

* On the "Graph Format Conversion" page, you can't click the toggle at all, since the element to the
  left of it somehow covers it up.
* On the "Model Browser" page the layout is a little ugly, as the text box and the toggle are
  too close to each other.
