### PR TITLE
Make index link on conversion page same as other pages

### DIFF
--- a/client/src/conversion/conversion_template.html
+++ b/client/src/conversion/conversion_template.html
@@ -15,7 +15,10 @@
 </head>
 <body class="d-flex flex-column">
     <nav class="navbar navbar-expand-sm navbar-default flex-nowrap">
-        <a class="navbar-brand w-100" href="index.html">ELK Graph Viewers</a>
+        <a class="navbar-brand w-100" href="index.html">
+            <span class="elk-logo-small align-top mr-1"></span>
+            ELK Demonstrators
+        </a>
         <div class="w-100 text-center">
              <span class="navbar-brand mb-0 h1">Graph Conversion</span>
         </div>


### PR DESCRIPTION
I noticed that the link at the upper left corner of the "Graph Conversion" page is different from all the others.
It has no logo, and says "Graph Viewers" instead of "Demonstrators".